### PR TITLE
Simplify the user interface to make it more intuitive and responsive, and also improve the feedback provided to users

### DIFF
--- a/backend/internal/core/services/reporting/io_sheet.go
+++ b/backend/internal/core/services/reporting/io_sheet.go
@@ -41,6 +41,12 @@ func (s *IOSheet) indexHeaders() {
 	}
 }
 
+// Ooi J Sen
+// function to return headers from excel sheet
+func (s *IOSheet) GetHeaders() []string {
+    return s.headers
+}
+
 func (s *IOSheet) GetColumn(str string) (col int, ok bool) {
 	if s.index == nil {
 		s.indexHeaders()

--- a/backend/internal/core/services/service_items.go
+++ b/backend/internal/core/services/service_items.go
@@ -92,15 +92,31 @@ func serializeLocation[T ~[]string](location T) string {
 // Ooi J Sen
 // Function to validate headers
 func validateHeaders(expected, actual []string) bool {
-	if len(expected) != len(actual) {
-		return false
+	actualHeaderCount := make(map[string]int)
+
+	// Count occurrences of headers in the actual slice
+	for _, header := range actual {
+		actualHeaderCount[header]++
 	}
-	for i := range expected {
-		if expected[i] != actual[i] {
+
+	// Check if all actual headers are within the expected headers
+	for header, count := range actualHeaderCount {
+		if count > 0 && !contains(expected, header) {
 			return false
 		}
 	}
+
 	return true
+}
+
+// Function to check if a string slice contains a specific string
+func contains(slice []string, str string) bool {
+	for _, s := range slice {
+		if s == str {
+			return true
+		}
+	}
+	return false
 }
 
 // CsvImport imports items from a CSV file. using the standard defined format.

--- a/backend/internal/core/services/service_items.go
+++ b/backend/internal/core/services/service_items.go
@@ -185,8 +185,12 @@ func (svc *ItemService) CsvImport(ctx context.Context, GID uuid.UUID, data io.Re
 
 	finished := 0
 
+	var errorMessage string
+
 	for i := range sheet.Rows {
 		row := sheet.Rows[i]
+		
+		var hasNegativeValues bool
 
 		createRequired := true
 
@@ -201,6 +205,25 @@ func (svc *ItemService) CsvImport(ctx context.Context, GID uuid.UUID, data io.Re
 			if exists {
 				createRequired = false
 			}
+		}
+		
+		// Ooi J Sen
+		// Check integer fields for negative values
+		if row.Quantity < 0 {
+			errorMessage += fmt.Sprintf("Negative quantity at row %d\n", i+1)
+			hasNegativeValues = true
+		}
+		if row.PurchasePrice < 0 {
+			errorMessage += fmt.Sprintf("Negative purchase price at row %d\n", i+1)
+			hasNegativeValues = true
+		}
+		if row.SoldPrice < 0 {
+			errorMessage += fmt.Sprintf("Negative sold price at row %d\n", i+1)
+			hasNegativeValues = true
+		}
+
+		if (hasNegativeValues) {
+			continue
 		}
 
 		// ========================================
@@ -348,6 +371,15 @@ func (svc *ItemService) CsvImport(ctx context.Context, GID uuid.UUID, data io.Re
 		}
 
 		finished++
+	}
+
+	// Ooi J Sen
+	// Display error messages in console
+	if errorMessage != "" {
+		// Log or handle the error message here
+		fmt.Println("Error Messages:")
+		fmt.Println(errorMessage)
+		return 0, fmt.Errorf("Errors detected in CSV:\n%s", errorMessage)
 	}
 
 	return finished, nil

--- a/backend/internal/core/services/service_items.go
+++ b/backend/internal/core/services/service_items.go
@@ -89,6 +89,20 @@ func serializeLocation[T ~[]string](location T) string {
 	return strings.Join(location, "/")
 }
 
+// Ooi J Sen
+// Function to validate headers
+func validateHeaders(expected, actual []string) bool {
+	if len(expected) != len(actual) {
+		return false
+	}
+	for i := range expected {
+		if expected[i] != actual[i] {
+			return false
+		}
+	}
+	return true
+}
+
 // CsvImport imports items from a CSV file. using the standard defined format.
 //
 // CsvImport applies the following rules/operations
@@ -102,6 +116,16 @@ func (svc *ItemService) CsvImport(ctx context.Context, GID uuid.UUID, data io.Re
 	err := sheet.Read(data)
 	if err != nil {
 		return 0, err
+	}
+	
+	// Ooi J Sen
+	// Access excel sheet headers
+	headers := sheet.GetHeaders()
+
+	// Validate column headers
+	expectedHeaders := []string{"HB.import_ref", "HB.location", "HB.labels", "HB.asset_id", "HB.archived", "HB.name", "HB.quantity", "HB.description", "HB.insured", "HB.notes", "HB.purchase_price", "HB.purchase_from", "HB.purchase_time", "HB.manufacturer", "HB.model_number", "HB.serial_number", "HB.lifetime_warranty", "HB.warranty_expires", "HB.warranty_details", "HB.sold_to", "HB.sold_price", "HB.sold_time", "HB.sold_notes",}
+	if !validateHeaders(expectedHeaders, headers) {
+		return 0, fmt.Errorf("CSV columns do not match the expected format")
 	}
 
 	// ========================================

--- a/frontend/components/ModalConfirm.vue
+++ b/frontend/components/ModalConfirm.vue
@@ -1,7 +1,7 @@
 <template>
   <BaseModal v-model="isRevealed" readonly @cancel="cancel(false)">
-    <template #title> Confirm </template>
-    <div>
+    <template #title> Confirm {{ title }}</template>
+    <div class="mt-3">
       <p>{{ text }}</p>
     </div>
     <div class="modal-action">
@@ -11,5 +11,5 @@
 </template>
 
 <script setup lang="ts">
-  const { text, isRevealed, confirm, cancel } = useConfirm();
+  const { title, text, isRevealed, confirm, cancel } = useConfirm();
 </script>

--- a/frontend/components/global/Markdown.vue
+++ b/frontend/components/global/Markdown.vue
@@ -23,7 +23,9 @@
 </script>
 
 <template>
+  <!-- eslint-disable vue/no-v-html -->
   <div class="markdown" v-html="raw"></div>
+  <!--eslint-enable-->
 </template>
 
 <style scoped>

--- a/frontend/composables/use-confirm.ts
+++ b/frontend/composables/use-confirm.ts
@@ -2,12 +2,14 @@ import { UseConfirmDialogRevealResult, UseConfirmDialogReturn } from "@vueuse/co
 import { Ref } from "vue";
 
 type Store = UseConfirmDialogReturn<any, boolean, boolean> & {
+  title: Ref<string>;
   text: Ref<string>;
   setup: boolean;
-  open: (text: string) => Promise<UseConfirmDialogRevealResult<boolean, boolean>>;
+  open: (title: string, text: string) => Promise<UseConfirmDialogRevealResult<boolean, boolean>>;
 };
 
 const store: Partial<Store> = {
+  title: ref("Confirm"),
   text: ref("Are you sure you want to delete this item? "),
   setup: false,
 };
@@ -30,14 +32,18 @@ export function useConfirm(): Store {
     store.cancel = cancel;
   }
 
-  async function openDialog(msg: string): Promise<UseConfirmDialogRevealResult<boolean, boolean>> {
+  async function openDialog(title: string, msg: string): Promise<UseConfirmDialogRevealResult<boolean, boolean>> {
     if (!store.reveal) {
       throw new Error("reveal is not defined");
     }
     if (!store.text) {
       throw new Error("text is not defined");
     }
-
+    if (!store.title) {
+      throw new Error("title is not defined");
+    }
+  
+    store.title.value = title;
     store.text.value = msg;
     return await store.reveal();
   }

--- a/frontend/composables/use-confirm.ts
+++ b/frontend/composables/use-confirm.ts
@@ -42,7 +42,7 @@ export function useConfirm(): Store {
     if (!store.title) {
       throw new Error("title is not defined");
     }
-  
+
     store.title.value = title;
     store.text.value = msg;
     return await store.reveal();

--- a/frontend/pages/item/[id]/index.vue
+++ b/frontend/pages/item/[id]/index.vue
@@ -586,7 +586,7 @@
         </template>
       </div>
     </section>
-    
+
     <section v-if="items && items.length > 0" class="my-6">
       <ItemViewSelectable :items="items" />
     </section>

--- a/frontend/pages/item/[id]/index.vue
+++ b/frontend/pages/item/[id]/index.vue
@@ -63,6 +63,10 @@
     item.value.quantity = newQuantity;
   }
 
+  function navigateToEdit() {
+    navigateTo(`/item/${itemId.value}/edit`);
+  }
+
   type FilteredAttachments = {
     attachments: ItemAttachment[];
     warranty: ItemAttachment[];
@@ -397,11 +401,6 @@
         name: "Maintenance",
         to: `/item/${itemId.value}/maintenance`,
       },
-      {
-        id: "edit",
-        name: "Edit",
-        to: `/item/${itemId.value}/edit`,
-      },
     ];
   });
 
@@ -494,7 +493,13 @@
                 <input v-model="preferences.showEmpty" type="checkbox" class="toggle toggle-primary" />
                 <span class="label-text ml-4"> Show Empty </span>
               </label>
-              <PageQRCode />
+              <div class="flex items-end gap-5 mr-3">
+                <PageQRCode />
+                <BaseButton size="sm" @click="navigateToEdit">
+                  <Icon class="mr-4" name="mdi-pencil" />
+                  Edit
+                </BaseButton>
+              </div>
             </div>
           </template>
           <DetailsSection :details="itemDetails">
@@ -581,7 +586,7 @@
         </template>
       </div>
     </section>
-
+    
     <section v-if="items && items.length > 0" class="my-6">
       <ItemViewSelectable :items="items" />
     </section>

--- a/frontend/pages/item/[id]/index/edit.vue
+++ b/frontend/pages/item/[id]/index/edit.vue
@@ -371,7 +371,7 @@
   const parent = ref();
 
   async function deleteItem() {
-    const confirmed = await confirm.open("Are you sure you want to delete this item?");
+    const confirmed = await confirm.open("Delete Item", "Are you sure you want to delete this item?");
 
     if (!confirmed.data) {
       return;

--- a/frontend/pages/item/[id]/index/edit.vue
+++ b/frontend/pages/item/[id]/index/edit.vue
@@ -286,7 +286,7 @@
   const confirm = useConfirm();
 
   async function deleteAttachment(attachmentId: string) {
-    const confirmed = await confirm.open("Delete Attachment" , "Are you sure you want to delete this attachment?");
+    const confirmed = await confirm.open("Delete Attachment", "Are you sure you want to delete this attachment?");
 
     if (confirmed.isCanceled) {
       return;

--- a/frontend/pages/item/[id]/index/edit.vue
+++ b/frontend/pages/item/[id]/index/edit.vue
@@ -286,7 +286,7 @@
   const confirm = useConfirm();
 
   async function deleteAttachment(attachmentId: string) {
-    const confirmed = await confirm.open("Are you sure you want to delete this attachment?");
+    const confirmed = await confirm.open("Delete Attachment" , "Are you sure you want to delete this attachment?");
 
     if (confirmed.isCanceled) {
       return;
@@ -521,7 +521,7 @@
               <div class="flex items-end col-span-3">
                 <FormTextField v-model="field.textValue" label="Value" />
                 <div class="tooltip" data-tip="Delete">
-                  <button class="btn btn-sm btn-square mb-2 ml-2" @click="item.fields.splice(idx, 1)">
+                  <button class="btn btn-sm btn-square mb-2 ml-2 btn-error" @click="item.fields.splice(idx, 1)">
                     <Icon name="mdi-delete" />
                   </button>
                 </div>
@@ -575,7 +575,7 @@
                 </p>
                 <div class="flex gap-2 justify-end">
                   <div class="tooltip" data-tip="Delete">
-                    <button class="btn btn-sm btn-square" @click="deleteAttachment(attachment.id)">
+                    <button class="btn btn-sm btn-square btn-error" @click="deleteAttachment(attachment.id)">
                       <Icon name="mdi-delete" />
                     </button>
                   </div>

--- a/frontend/pages/item/[id]/index/maintenance.vue
+++ b/frontend/pages/item/[id]/index/maintenance.vue
@@ -122,7 +122,7 @@
   const confirm = useConfirm();
 
   async function deleteEntry(id: string) {
-    const result = await confirm.open("Are you sure you want to delete this entry?");
+    const result = await confirm.open("Delete Maintenance Entry", "Are you sure you want to delete this entry?");
     if (result.isCanceled) {
       return;
     }
@@ -253,7 +253,7 @@
               </template>
               Edit
             </BaseButton>
-            <BaseButton size="sm" @click="deleteEntry(e.id)">
+            <BaseButton class="btn-error" size="sm" @click="deleteEntry(e.id)">
               <template #icon>
                 <Icon name="mdi-delete" />
               </template>

--- a/frontend/pages/label/[id].vue
+++ b/frontend/pages/label/[id].vue
@@ -23,7 +23,7 @@
 
   async function confirmDelete() {
     const { isCanceled } = await confirm.open(
-      "Are you sure you want to delete this label? This action cannot be undone."
+      "Delete Label" , "Are you sure you want to delete this label? This action cannot be undone."
     );
 
     if (isCanceled) {
@@ -93,8 +93,8 @@
     <BaseModal v-model="updateModal">
       <template #title> Update Label </template>
       <form v-if="label" @submit.prevent="update">
-        <FormTextField v-model="updateData.name" :autofocus="true" label="Label Name" />
-        <FormTextArea v-model="updateData.description" label="Label Description" />
+        <FormTextField class="mt-3" v-model="updateData.name" :autofocus="true" label="Label Name" />
+        <FormTextArea class="mt-2" v-model="updateData.description" label="Label Description" />
         <div class="modal-action">
           <BaseButton type="submit" :loading="updating"> Update </BaseButton>
         </div>
@@ -106,8 +106,8 @@
         <header class="mb-2">
           <div class="flex flex-wrap items-end gap-2">
             <div class="avatar placeholder mb-auto">
-              <div class="bg-neutral-focus text-neutral-content rounded-full w-12">
-                <Icon name="mdi-package-variant" class="h-7 w-7" />
+              <div class="bg-neutral-focus text-neutral-content rounded-full w-12 ml-2">
+                <Icon name="heroicons-tag" class="h-7 w-7" />
               </div>
             </div>
             <div>
@@ -121,15 +121,13 @@
                 </div>
               </div>
             </div>
-            <div class="ml-auto mt-2 flex flex-wrap items-center justify-between gap-3">
-              <div class="btn-group">
-                <PageQRCode class="dropdown-left" />
-                <BaseButton size="sm" @click="openUpdate">
-                  <Icon class="mr-1" name="mdi-pencil" />
-                  Edit
-                </BaseButton>
-              </div>
-              <BaseButton class="btn btn-sm" @click="confirmDelete()">
+            <div class="ml-auto mt-2 mr-3 flex flex-wrap items-center justify-between gap-3">
+              <PageQRCode class="dropdown-left" />
+              <BaseButton size="sm" @click="openUpdate">
+                <Icon class="mr-2" name="mdi-pencil" />
+                Edit
+              </BaseButton>
+              <BaseButton class="btn btn-sm btn-error" @click="confirmDelete()">
                 <Icon name="mdi-delete" class="mr-2" />
                 Delete
               </BaseButton>
@@ -137,7 +135,7 @@
           </div>
         </header>
         <div class="divider my-0 mb-1"></div>
-        <Markdown v-if="label && label.description" class="text-base" :source="label.description"> </Markdown>
+        <Markdown v-if="label && label.description" class="text-base ml-2" :source="label.description"> </Markdown>
       </div>
       <section v-if="label && items">
         <ItemViewSelectable :items="items" />

--- a/frontend/pages/label/[id].vue
+++ b/frontend/pages/label/[id].vue
@@ -23,7 +23,8 @@
 
   async function confirmDelete() {
     const { isCanceled } = await confirm.open(
-      "Delete Label" , "Are you sure you want to delete this label? This action cannot be undone."
+      "Delete Label",
+      "Are you sure you want to delete this label? This action cannot be undone."
     );
 
     if (isCanceled) {
@@ -93,8 +94,8 @@
     <BaseModal v-model="updateModal">
       <template #title> Update Label </template>
       <form v-if="label" @submit.prevent="update">
-        <FormTextField class="mt-3" v-model="updateData.name" :autofocus="true" label="Label Name" />
-        <FormTextArea class="mt-2" v-model="updateData.description" label="Label Description" />
+        <FormTextField v-model="updateData.name" class="mt-3" :autofocus="true" label="Label Name" />
+        <FormTextArea v-model="updateData.description" class="mt-2" label="Label Description" />
         <div class="modal-action">
           <BaseButton type="submit" :loading="updating"> Update </BaseButton>
         </div>

--- a/frontend/pages/location/[id].vue
+++ b/frontend/pages/location/[id].vue
@@ -31,7 +31,7 @@
 
   async function confirmDelete() {
     const { isCanceled } = await confirm.open(
-      "Are you sure you want to delete this location and all of its items? This action cannot be undone."
+      "Delete Location", "Are you sure you want to delete this location and all of its items? This action cannot be undone."
     );
     if (isCanceled) {
       return;
@@ -108,9 +108,9 @@
     <BaseModal v-model="updateModal">
       <template #title> Update Location </template>
       <form v-if="location" @submit.prevent="update">
-        <FormTextField v-model="updateData.name" :autofocus="true" label="Location Name" />
-        <FormTextArea v-model="updateData.description" label="Location Description" />
-        <LocationSelector v-model="parent" />
+        <FormTextField class="mt-3" v-model="updateData.name" :autofocus="true" label="Location Name" />
+        <FormTextArea class="mt-2" v-model="updateData.description" label="Location Description" />
+        <LocationSelector class="mt-2" v-model="parent" />
         <div class="modal-action">
           <BaseButton type="submit" :loading="updating"> Update </BaseButton>
         </div>
@@ -122,8 +122,8 @@
         <header class="mb-2">
           <div class="flex flex-wrap items-end gap-2">
             <div class="avatar placeholder mb-auto">
-              <div class="bg-neutral-focus text-neutral-content rounded-full w-12">
-                <Icon name="mdi-package-variant" class="h-7 w-7" />
+              <div class="bg-neutral-focus text-neutral-content rounded-full w-12 ml-2">
+                <Icon name="heroicons-map-pin" class="h-7 w-7" />
               </div>
             </div>
             <div>
@@ -145,15 +145,13 @@
                 </div>
               </div>
             </div>
-            <div class="ml-auto mt-2 flex flex-wrap items-center justify-between gap-3">
-              <div class="btn-group">
-                <PageQRCode class="dropdown-left" />
-                <BaseButton size="sm" @click="openUpdate">
-                  <Icon class="mr-1" name="mdi-pencil" />
-                  Edit
-                </BaseButton>
-              </div>
-              <BaseButton class="btn btn-sm" @click="confirmDelete()">
+            <div class="ml-auto mt-2 mr-3 flex flex-wrap items-center justify-between gap-3">
+              <PageQRCode class="dropdown-left" />
+              <BaseButton size="sm" @click="openUpdate">
+                <Icon class="mr-2" name="mdi-pencil" />
+                Edit
+              </BaseButton>
+              <BaseButton class="btn btn-sm btn-error" @click="confirmDelete()">
                 <Icon name="mdi-delete" class="mr-2" />
                 Delete
               </BaseButton>
@@ -161,7 +159,7 @@
           </div>
         </header>
         <div class="divider my-0 mb-1"></div>
-        <Markdown v-if="location && location.description" class="text-base" :source="location.description"> </Markdown>
+        <Markdown v-if="location && location.description" class="text-base ml-2" :source="location.description"> </Markdown>
       </div>
       <section v-if="location && items">
         <ItemViewSelectable :items="items" />

--- a/frontend/pages/location/[id].vue
+++ b/frontend/pages/location/[id].vue
@@ -31,7 +31,8 @@
 
   async function confirmDelete() {
     const { isCanceled } = await confirm.open(
-      "Delete Location", "Are you sure you want to delete this location and all of its items? This action cannot be undone."
+      "Delete Location",
+      "Are you sure you want to delete this location and all of its items? This action cannot be undone."
     );
     if (isCanceled) {
       return;
@@ -108,9 +109,9 @@
     <BaseModal v-model="updateModal">
       <template #title> Update Location </template>
       <form v-if="location" @submit.prevent="update">
-        <FormTextField class="mt-3" v-model="updateData.name" :autofocus="true" label="Location Name" />
-        <FormTextArea class="mt-2" v-model="updateData.description" label="Location Description" />
-        <LocationSelector class="mt-2" v-model="parent" />
+        <FormTextField v-model="updateData.name" class="mt-3" :autofocus="true" label="Location Name" />
+        <FormTextArea v-model="updateData.description" class="mt-2" label="Location Description" />
+        <LocationSelector v-model="parent" class="mt-2" />
         <div class="modal-action">
           <BaseButton type="submit" :loading="updating"> Update </BaseButton>
         </div>
@@ -159,7 +160,8 @@
           </div>
         </header>
         <div class="divider my-0 mb-1"></div>
-        <Markdown v-if="location && location.description" class="text-base ml-2" :source="location.description"> </Markdown>
+        <Markdown v-if="location && location.description" class="text-base ml-2" :source="location.description">
+        </Markdown>
       </div>
       <section v-if="location && items">
         <ItemViewSelectable :items="items" />

--- a/frontend/pages/profile.vue
+++ b/frontend/pages/profile.vue
@@ -97,7 +97,8 @@
 
   async function deleteProfile() {
     const result = await confirm.open(
-      "Delete Account", "Are you sure you want to delete your account? If you are the last member in your group all your data will be deleted. This action cannot be undone."
+      "Delete Account",
+      "Are you sure you want to delete your account? If you are the last member in your group all your data will be deleted. This action cannot be undone."
     );
 
     if (result.isCanceled) {

--- a/frontend/pages/profile.vue
+++ b/frontend/pages/profile.vue
@@ -97,7 +97,7 @@
 
   async function deleteProfile() {
     const result = await confirm.open(
-      "Are you sure you want to delete your account? If you are the last member in your group all your data will be deleted. This action cannot be undone."
+      "Delete Account", "Are you sure you want to delete your account? If you are the last member in your group all your data will be deleted. This action cannot be undone."
     );
 
     if (result.isCanceled) {
@@ -251,7 +251,7 @@
   }
 
   async function deleteNotifier(id: string) {
-    const result = await confirm.open("Are you sure you want to delete this notifier?");
+    const result = await confirm.open("Delete Notifier", "Are you sure you want to delete this notifier?");
 
     if (result.isCanceled) {
       return;
@@ -367,7 +367,7 @@
               <p class="mr-auto text-lg">{{ n.name }}</p>
               <div class="flex gap-2 justify-end">
                 <div class="tooltip" data-tip="Delete">
-                  <button class="btn btn-sm btn-square" @click="deleteNotifier(n.id)">
+                  <button class="btn btn-sm btn-square btn-error" @click="deleteNotifier(n.id)">
                     <Icon name="mdi-delete" />
                   </button>
                 </div>

--- a/frontend/pages/tools.vue
+++ b/frontend/pages/tools.vue
@@ -125,7 +125,7 @@
 
   async function ensureAssetIDs() {
     const { isCanceled } = await confirm.open(
-      "Are you sure you want to ensure all assets have an ID? This can take a while and cannot be undone."
+      "Ensure Asset IDs", "Are you sure you want to ensure all assets have an ID? This can take a while and cannot be undone."
     );
 
     if (isCanceled) {

--- a/frontend/pages/tools.vue
+++ b/frontend/pages/tools.vue
@@ -125,7 +125,8 @@
 
   async function ensureAssetIDs() {
     const { isCanceled } = await confirm.open(
-      "Ensure Asset IDs", "Are you sure you want to ensure all assets have an ID? This can take a while and cannot be undone."
+      "Ensure Asset IDs",
+      "Are you sure you want to ensure all assets have an ID? This can take a while and cannot be undone."
     );
 
     if (isCanceled) {

--- a/frontend/pages/tools.vue
+++ b/frontend/pages/tools.vue
@@ -145,6 +145,7 @@
 
   async function ensureImportRefs() {
     const { isCanceled } = await confirm.open(
+      "Ensure Import Refs",
       "Are you sure you want to ensure all assets have an import_ref? This can take a while and cannot be undone."
     );
 
@@ -164,6 +165,7 @@
 
   async function resetItemDateTimes() {
     const { isCanceled } = await confirm.open(
+      "Reset All Date and Time Values",
       "Are you sure you want to reset all date and time values? This can take a while and cannot be undone."
     );
 
@@ -183,6 +185,7 @@
 
   async function setPrimaryPhotos() {
     const { isCanceled } = await confirm.open(
+      "Set Primary Photos",
       "Are you sure you want to set primary photos? This can take a while and cannot be undone."
     );
 


### PR DESCRIPTION
I modified some user interface as listed below: 

1. I changed all 'delete' button to red button to maintain the consistency of the appearance for 'delete' button. 
2. In specific 'location' or 'label' page, I modified the icon to match with the icon of 'location' and 'label' used in the website instead of using the package icon for both.
3. In the 'confirm' dialog, I added a new parameter, 'title' to let the confirm dialog have different titles so that it is more meaningful and user can understand what the dialog is for.
4. In 'item' details page, I removed the 'edit' tab and I move the edit icon to the 'details' card. 